### PR TITLE
Fix nginx 404 errors for static assets in Docker deployment

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -27,6 +27,7 @@ server {
     
     # Cache static assets
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        root /usr/share/nginx/html;
         expires 1y;
         add_header Cache-Control "public, immutable";
     }


### PR DESCRIPTION
## Summary
- Fix nginx 404 errors for static assets (JS, CSS files) when running Docker Compose
- Add missing `root` directive to static assets location block in nginx.conf

## Test plan
- [x] Build Docker image without cache
- [x] Start container with `docker compose up -d med-cvss-calculator`
- [x] Verify application loads correctly at http://localhost:3000
- [x] Verify static assets (JS/CSS) load without 404 errors
- [x] Test direct access to static files returns 200 status

🤖 Generated with [Claude Code](https://claude.ai/code)