### PR TITLE
Add collapse/expand all metrics functionality

### DIFF
--- a/med-cvss-calculator/src/components/IntegratedCVSSCalculator.css
+++ b/med-cvss-calculator/src/components/IntegratedCVSSCalculator.css
@@ -332,6 +332,24 @@
   background: #c0392b;
 }
 
+.collapse-all-button,
+.expand-all-button {
+  padding: 8px 16px;
+  background: #3498db;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: background-color 0.2s ease;
+}
+
+.collapse-all-button:hover,
+.expand-all-button:hover {
+  background: #2980b9;
+}
+
 .metrics-status {
   font-size: 14px;
   font-weight: 500;
@@ -813,7 +831,9 @@
     gap: 12px;
   }
 
-  .clear-all-button {
+  .clear-all-button,
+  .collapse-all-button,
+  .expand-all-button {
     width: 100%;
     justify-self: center;
   }

--- a/med-cvss-calculator/src/components/IntegratedCVSSCalculator.tsx
+++ b/med-cvss-calculator/src/components/IntegratedCVSSCalculator.tsx
@@ -267,6 +267,15 @@ const IntegratedCVSSCalculator: React.FC = () => {
     });
   };
 
+  const collapseAllMetrics = () => {
+    const allMetricKeys = getCurrentMetrics().flatMap((group) => Object.keys(group.metrics));
+    setCollapsedIndividualMetrics(new Set(allMetricKeys));
+  };
+
+  const expandAllMetrics = () => {
+    setCollapsedIndividualMetrics(new Set());
+  };
+
   const getCurrentMetrics = () => (version === '3.1' ? cvssMetrics : cvssV4Metrics);
   const getCurrentDescriptions = () =>
     version === '3.1' ? metricDescriptions : cvssV4MetricDescriptions;
@@ -476,6 +485,12 @@ const IntegratedCVSSCalculator: React.FC = () => {
           <div className='quick-actions'>
             <button className='clear-all-button' onClick={clearAllMetrics}>
               Clear All Metrics
+            </button>
+            <button className='collapse-all-button' onClick={collapseAllMetrics}>
+              Collapse All Metrics
+            </button>
+            <button className='expand-all-button' onClick={expandAllMetrics}>
+              Expand All Metrics
             </button>
             <div className='metrics-status'>
               {allRequiredMetricsSelected() ? (


### PR DESCRIPTION
## Summary
- Add functionality to collapse or expand all individual CVSS metrics at once
- Add "Collapse All Metrics" and "Expand All Metrics" buttons to the quick actions section
- Enhance user experience when working with large metric sets in both CVSS v3.1 and v4.0

## Test plan
- [ ] Verify "Collapse All Metrics" button collapses all individual metrics
- [ ] Verify "Expand All Metrics" button expands all individual metrics  
- [ ] Test functionality works correctly in both CVSS v3.1 and v4.0 modes
- [ ] Confirm buttons are properly styled and responsive on mobile devices
- [ ] Ensure existing individual metric collapse/expand functionality still works
- [ ] Run quality checks: `npm run quality`

🤖 Generated with [Claude Code](https://claude.ai/code)