### PR TITLE
Fix CVSS version switching error

### DIFF
--- a/med-cvss-calculator/src/utils/cvssCalculator.ts
+++ b/med-cvss-calculator/src/utils/cvssCalculator.ts
@@ -112,7 +112,17 @@ export function calculateUniversalCVSSScore(
   version: CVSSVersion
 ): CVSSScore {
   if (version === '4.0') {
-    return calculateCVSSV4Score(vector as CVSSV4Vector);
+    // Filter out v3.1 specific metrics that are not valid in v4.0
+    const v4Vector: CVSSV4Vector = {};
+    const v31SpecificMetrics = ['S', 'RL', 'RC']; // Scope, Remediation Level, Report Confidence
+
+    Object.entries(vector).forEach(([key, value]) => {
+      if (!v31SpecificMetrics.includes(key)) {
+        (v4Vector as any)[key] = value;
+      }
+    });
+
+    return calculateCVSSV4Score(v4Vector);
   } else {
     return calculateCVSSScore(vector as CVSSVector);
   }
@@ -123,7 +133,17 @@ export function generateUniversalVectorString(
   version: CVSSVersion
 ): string {
   if (version === '4.0') {
-    return generateV4VectorString(vector as CVSSV4Vector);
+    // Filter out v3.1 specific metrics that are not valid in v4.0
+    const v4Vector: CVSSV4Vector = {};
+    const v31SpecificMetrics = ['S', 'RL', 'RC']; // Scope, Remediation Level, Report Confidence
+
+    Object.entries(vector).forEach(([key, value]) => {
+      if (!v31SpecificMetrics.includes(key)) {
+        (v4Vector as any)[key] = value;
+      }
+    });
+
+    return generateV4VectorString(v4Vector);
   } else {
     return generateVectorString(vector as CVSSVector);
   }


### PR DESCRIPTION
## Summary
- Fixed error when switching from CVSS v3.1 to v4.0 in the calculator
- Filtered out v3.1-specific metrics (Scope, Remediation Level, Report Confidence) that are incompatible with v4.0

## Problem
When users switched from CVSS v3.1 to v4.0, the application would throw:
```
Error: invalid vector, missing mandatory metrics
Error: Invalid CVSS v4.0 vector: CVSS:4.0/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
```

This happened because the v3.1 vector included metrics like `S:U` (Scope) that don't exist in v4.0.

## Solution
Added filtering logic in `calculateUniversalCVSSScore` and `generateUniversalVectorString` to remove v3.1-specific metrics when switching to v4.0.

## Test plan
- [x] Run existing tests: `npm test`
- [x] Type checking passes: `npm run type-check`
- [x] Build succeeds: `npm run build`
- [ ] Manual testing: Switch between v3.1 and v4.0 in the UI to verify no errors occur

🤖 Generated with [Claude Code](https://claude.ai/code)