### PR TITLE
Add HTTP API support for MCP server deployment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,12 +145,53 @@ The application integrates with the [med-mcp-threat server](https://github.com/o
 **Environment Variables:**
 ```bash
 REACT_APP_MCP_ENABLED=true
+REACT_APP_MCP_THREAT_SERVER=threat-extraction  # For Claude Desktop mode
+REACT_APP_MCP_SERVER_URL=https://your-mcp-server.vercel.app  # For HTTP API mode
+```
+
+**MCP Server Configuration:**
+MCPサーバーは2つの方法で設定可能です：
+
+**Option 1: Claude Desktop (ローカル)**
+1. **Claude Desktop設定** (`claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "threat-extraction": {
+      "command": "node",
+      "args": ["/path/to/med-mcp-threat/index.js"],
+      "env": {
+        "PORT": "3001"
+      }
+    }
+  }
+}
+```
+
+2. **環境変数設定** (`.env.local`):
+```bash
 REACT_APP_MCP_THREAT_SERVER=threat-extraction
+# REACT_APP_MCP_SERVER_URL は設定しない（Claude Desktopモード）
+```
+
+**Option 2: HTTP API (Vercel等にデプロイ)**
+1. **MCPサーバーをVercel等にデプロイ**
+2. **環境変数設定** (`.env.local`):
+```bash
+REACT_APP_MCP_SERVER_URL=https://your-mcp-server.vercel.app
+# REACT_APP_MCP_THREAT_SERVER は不要（HTTP APIモード）
+```
+
+**HTTP API Endpoints:**
+```
+GET  /health                     # ヘルスチェック
+POST /api/extract-cvss           # 単一脅威分析
+POST /api/extract-cvss-batch     # バッチ脅威分析
 ```
 
 **Requirements:**
-- Claude Desktop with MCP support
-- med-mcp-threat server configured
+- Option 1: Claude Desktop with MCP support + med-mcp-threat server configured locally
+- Option 2: med-mcp-threat server deployed as HTTP API (Vercel, etc.)
 - User authentication (protected route)
 
 ## Important Implementation Details

--- a/med-cvss-calculator/.env.example
+++ b/med-cvss-calculator/.env.example
@@ -19,5 +19,11 @@ REACT_APP_DEFAULT_STORAGE_TYPE=localStorage
 # MCP Threat Extraction Configuration
 # Enable MCP threat extraction features
 REACT_APP_MCP_ENABLED=true
-# MCP server name for threat extraction
+
+# Option 1: Claude Desktop MCP (local)
+# MCP server name for threat extraction (Claude Desktop)
 REACT_APP_MCP_THREAT_SERVER=threat-extraction
+
+# Option 2: HTTP API (Vercel/remote deployment)
+# MCP server URL for HTTP API (if set, HTTP API mode is used)
+# REACT_APP_MCP_SERVER_URL=https://your-mcp-server.vercel.app

--- a/med-cvss-calculator/src/services/mcpClient.ts
+++ b/med-cvss-calculator/src/services/mcpClient.ts
@@ -25,16 +25,16 @@ export interface MCPBatchResult {
  * This service communicates with the med-mcp-threat server via the MCP protocol
  */
 class MCPThreatExtractionClient {
-  private serverName = 'threat-extraction';
+  private serverName = process.env.REACT_APP_MCP_THREAT_SERVER || 'threat-extraction';
+  private serverUrl = process.env.REACT_APP_MCP_SERVER_URL || '';
   private isConnected = false;
+  private useHttpApi = !!process.env.REACT_APP_MCP_SERVER_URL;
 
   /**
    * Initialize connection to MCP server
    */
   async connect(): Promise<boolean> {
     try {
-      // In a real implementation, this would establish a connection to the MCP server
-      // For now, we'll simulate checking if the MCP tools are available
       const mcpAvailable = await this.checkMCPAvailability();
       this.isConnected = mcpAvailable;
       return mcpAvailable;
@@ -50,9 +50,25 @@ class MCPThreatExtractionClient {
    * Check if MCP tools are available
    */
   private async checkMCPAvailability(): Promise<boolean> {
-    // Check if we're running in an environment that supports MCP
-    // This could be Claude Desktop or another MCP-enabled client
-    return typeof (window as any).use_mcp_tool === 'function';
+    if (this.useHttpApi) {
+      // Check HTTP API availability
+      try {
+        const response = await fetch(`${this.serverUrl}/health`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+        return response.ok;
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn('HTTP API health check failed:', error);
+        return false;
+      }
+    } else {
+      // Check if we're running in Claude Desktop environment
+      return typeof (window as any).use_mcp_tool === 'function';
+    }
   }
 
   /**
@@ -64,13 +80,32 @@ class MCPThreatExtractionClient {
     }
 
     try {
-      // Use the MCP tool to extract CVSS metrics
-      const result = await (window as any).use_mcp_tool(this.serverName, 'extract_cvss', {
-        threat_description: threatDescription,
-      });
+      if (this.useHttpApi) {
+        // Use HTTP API for threat extraction
+        const response = await fetch(`${this.serverUrl}/api/extract-cvss`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            threat_description: threatDescription,
+          }),
+        });
 
-      // Transform the result to match our interface
-      return this.transformMCPResult(result, threatDescription);
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        const result = await response.json();
+        return this.transformMCPResult(result, threatDescription);
+      } else {
+        // Use Claude Desktop MCP tool
+        const result = await (window as any).use_mcp_tool(this.serverName, 'extract_cvss', {
+          threat_description: threatDescription,
+        });
+
+        return this.transformMCPResult(result, threatDescription);
+      }
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('MCP extraction error:', error);
@@ -87,13 +122,32 @@ class MCPThreatExtractionClient {
     }
 
     try {
-      // Use the MCP tool for batch processing
-      const result = await (window as any).use_mcp_tool(this.serverName, 'extract_cvss_batch', {
-        threat_descriptions: threatDescriptions,
-      });
+      if (this.useHttpApi) {
+        // Use HTTP API for batch processing
+        const response = await fetch(`${this.serverUrl}/api/extract-cvss-batch`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            threat_descriptions: threatDescriptions,
+          }),
+        });
 
-      // Transform the batch result
-      return this.transformMCPBatchResult(result);
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        const result = await response.json();
+        return this.transformMCPBatchResult(result);
+      } else {
+        // Use Claude Desktop MCP tool for batch processing
+        const result = await (window as any).use_mcp_tool(this.serverName, 'extract_cvss_batch', {
+          threat_descriptions: threatDescriptions,
+        });
+
+        return this.transformMCPBatchResult(result);
+      }
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('MCP batch extraction error:', error);
@@ -177,7 +231,16 @@ export const mcpThreatClient = new MCPThreatExtractionClient();
  * Helper function to check if MCP is available in the current environment
  */
 export const isMCPAvailable = (): boolean => {
-  return typeof (window as any).use_mcp_tool === 'function';
+  const serverUrl = process.env.REACT_APP_MCP_SERVER_URL;
+  
+  if (serverUrl) {
+    // For HTTP API mode, we assume it's available if URL is configured
+    // Actual availability check happens in connect()
+    return true;
+  } else {
+    // For Claude Desktop mode, check for use_mcp_tool function
+    return typeof (window as any).use_mcp_tool === 'function';
+  }
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add support for deploying MCP threat extraction server as HTTP API (e.g., Vercel)
- Maintain backward compatibility with existing Claude Desktop MCP integration
- Automatic mode detection based on environment configuration

## Changes
- **MCP Client Enhancement**: Support both Claude Desktop and HTTP API modes
- **Environment Variables**: Add `REACT_APP_MCP_SERVER_URL` for HTTP API mode
- **Health Check**: Add `/health` endpoint check for HTTP API availability
- **Documentation**: Update CLAUDE.md with both deployment options

## HTTP API Endpoints
- `GET /health` - Health check
- `POST /api/extract-cvss` - Single threat analysis  
- `POST /api/extract-cvss-batch` - Batch threat analysis

## Configuration Options

**Option 1: Claude Desktop (Local)**
```bash
REACT_APP_MCP_THREAT_SERVER=threat-extraction
# REACT_APP_MCP_SERVER_URL not set
```

**Option 2: HTTP API (Vercel)**
```bash
REACT_APP_MCP_SERVER_URL=https://your-mcp-server.vercel.app
# REACT_APP_MCP_THREAT_SERVER not needed
```

## Test plan
- [ ] Test Claude Desktop MCP integration (existing functionality)
- [ ] Test HTTP API integration with mock server
- [ ] Verify automatic mode detection
- [ ] Test error handling for both modes
- [ ] Verify health check functionality

🤖 Generated with [Claude Code](https://claude.ai/code)